### PR TITLE
Allow setting Timeslider interval

### DIFF
--- a/src/components/TimeSlider.vue
+++ b/src/components/TimeSlider.vue
@@ -57,7 +57,7 @@ export default class TimeSlider extends Vue {
   }
 
   get range(): [number, number] {
-    return [this.min - 1, this.max + 1];
+    return [this.min, this.max];
   }
   set range(range: [number, number]) {
     this.$emit("input", [new Date(range[0] * 1000), new Date(range[1] * 1000)]);

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -5,6 +5,7 @@
     </b-row>
     <b-row>
       <b-col>
+        <h2>Time slider interval in hours:</h2>
         <v-btn-toggle v-model="step" mandatory>
           <v-btn>
             <v-icon>1</v-icon>


### PR DESCRIPTION
Fixes #3 

A new menu entry in the top navbar has been added called "Settings".

There you can choose between an interval of 1, 2, 6 or 24 hours.

![image](https://user-images.githubusercontent.com/6696618/208718040-09533575-3fad-4966-a2af-1a3dfbc2e742.png)
