### PR TITLE
FIX: check before adding new BASE_URI directive to nginx

### DIFF
--- a/base_uri_envsubst_entrypoint.sh
+++ b/base_uri_envsubst_entrypoint.sh
@@ -5,5 +5,5 @@ CONFIG_FILE="/etc/nginx/conf.d/default.conf"
 
 if [ "$BASE_URI" != "/" ]; then
     LOCATION_BLOCK="\n    location $BASE_URI {\n        alias /usr/share/nginx/html/;\n    }"
-    sed -i "/^}$/i \\$LOCATION_BLOCK" $CONFIG_FILE
+    grep -q "location $BASE_URI" $CONFIG_FILE || sed -i "/^}$/i \\$LOCATION_BLOCK" $CONFIG_FILE
 fi


### PR DESCRIPTION
Simple check preventing writing the same location directive multiple times.
Currently, the entrypoint script adds the custom base uri location on every
startup, what leads to duplication and NGINX critical errors.

Fix #41
