### PR TITLE
Fix building with given base URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN corepack enable
 WORKDIR /usr/src/koordtool
 COPY . /usr/src/koordtool
 RUN pnpm install --frozen-lockfile &&\
-    pnpm run build -- --base=${BASE_URI}
+    pnpm run build --base=${BASE_URI}
 
 FROM nginx:stable-alpine
 WORKDIR /usr


### PR DESCRIPTION
Passing `--` to pnpm results with subsequent vite command to have it included as well and renders the CLI like: `vue-tsc && vite build "--" "--base" "/__KOORD_BASEURI__/"`. However, in this way the vite command does not treat `--base` as it's argument and renders files without the given base.
