### PR TITLE
Fix: Resolve duplicate colors in chart 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ If you want to be able to allow users to update their responses, set the followi
 in "Participants settings":
 
 - "Allow multiple responses or update responses with one access code" should be ON, and
-- "Enable participant-based response persistence" should be ON as well.
+- "Enable participant-based response persistence" should be ON as well, and 
+- Set "Closed-access mode" in the "Survey participants" menu.
 
 **Important:** You must turn "Anonymized responses" *off*, and turn "Date stamp" *on*.
 Otherwise, LimeSurvey will not store submission times and sets it to January 1, 1980.

--- a/src/api/limesurvey.ts
+++ b/src/api/limesurvey.ts
@@ -32,6 +32,8 @@ export class LimesurveyApi {
     if (username === "" || password === "") {
       throw new Error("LimeSurvey API username or password not configured");
     }
+    console.debug(`Authenticating with username: ${username} and: ${password}`)
+
     const session = await this.call<Auth>("get_session_key", false, username, password);
     if (session && typeof session === "string") {
       this.session = session;
@@ -195,6 +197,13 @@ export class LimesurveyApi {
     if (response.status !== 200) {
       const error = new Error(`Calling ${rpcMethod} failed`);
       store.error = error;
+      throw error;
+    }
+
+    if ( response.data == "" ) {
+      const error = new Error("Could not get Sessionkey, check is JSON-RPC is enabled");
+      store.error = error;
+      console.error("Could not get Sessionkey, check if JSON-RPC is enabled");
       throw error;
     }
 

--- a/src/api/limesurvey.ts
+++ b/src/api/limesurvey.ts
@@ -32,8 +32,6 @@ export class LimesurveyApi {
     if (username === "" || password === "") {
       throw new Error("LimeSurvey API username or password not configured");
     }
-    console.debug(`Authenticating with username: ${username} and: ${password}`)
-
     const session = await this.call<Auth>("get_session_key", false, username, password);
     if (session && typeof session === "string") {
       this.session = session;

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -39,7 +39,8 @@ export function countResponsesFor(questionKey: string): responseCount[] {
   let lastResponses = getLastResponses(addExpiredEntries(store.getFilteredResponses(questionKey)));
 
   lastResponses = filterNA(lastResponses);
-
+  console.debug("Filtered responses for key:", questionKey, lastResponses);
+  
   lastResponses.forEach((response) => {
     if (multiplechoice && typeof response.answer === "object") {
       const answers = response.answer as Record<string, string>;

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -38,9 +38,7 @@ export function countResponsesFor(questionKey: string): responseCount[] {
 
   let lastResponses = getLastResponses(addExpiredEntries(store.getFilteredResponses(questionKey)));
 
-  lastResponses = filterNA(lastResponses);
-  console.debug("Filtered responses for key:", questionKey, lastResponses);
-  
+  lastResponses = filterNA(lastResponses);  
   lastResponses.forEach((response) => {
     if (multiplechoice && typeof response.answer === "object") {
       const answers = response.answer as Record<string, string>;

--- a/src/helpers/shared-chartFunctions.ts
+++ b/src/helpers/shared-chartFunctions.ts
@@ -2,16 +2,16 @@ import { chartColors } from "../components/surveys/colors";
 import { FilteredResponse } from "../types/response.model";
 import { useSurveyStore } from "../store/surveyStore";
 
-export function getBorderColor(key: string): string {
-  let hash = 0;
-  for (let i = 0; i < key.length; i++) {
-    const char = key.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash |= 0;
-  }
-  const index = Math.abs(hash) % chartColors.length;
-  console.debug(`getBorderColor(${key}) => ${chartColors[index]} || ${index}`);
-  return chartColors[index];
+const keyToColorMap: Record<string, string> = {};
+
+export function getBorderColor(key:string) : string{
+  if (!keyToColorMap[key]) {
+    const index = Object.keys(keyToColorMap).length % chartColors.length;
+    keyToColorMap[key] = chartColors[index];
+  } 
+  console.debug(`getBorderColor new method!`);
+  console.debug(`getBorderColor(${key}) => ${keyToColorMap[key]} || index: ${Object.keys(keyToColorMap).length - 1}`);
+  return keyToColorMap[key];
 }
 
 function expirationDate(relativeDate: Date): Date {


### PR DESCRIPTION
Previously, the color assignment for the charts used a hashing function to map labels to indices in the color palette. This likely caused hash collisions.
This PR replaces the hashing system with a key to color mapping, to make sure we get unique colors for unique labels and a consistent behavior.

Added a check for mission session keys in the LimeSurvey API calls and updated the readme 