### PR TITLE
prevent survey data mixing during survey switches

### DIFF
--- a/src/store/surveyStore.ts
+++ b/src/store/surveyStore.ts
@@ -196,12 +196,17 @@ export const useSurveyStore = defineStore(
     }
 
     async function refreshSurvey(surveyId: number): Promise<void> {
+      resetSurvey();
       if (!(surveyId in surveys.value)) {
         await refreshSurveys();
       }
-
-      resetSurvey();
+    
       selectedSurveyID.value = surveyId;
+      
+      responses.value[surveyId] = [];
+      questions.value[surveyId] = {};
+      participants.value[surveyId] = [];
+      
       await Promise.all([
         refreshQuestions(surveyId),
         refreshResponses(surveyId),
@@ -306,6 +311,15 @@ export const useSurveyStore = defineStore(
     function resetSurvey() {
       tokenMap.value = {};
       responseRange.value = [0, new Date().getTime()];
+      questionKeys.value = [];
+      questionKeysWithSubquestions.value = [];
+      if (selectedSurveyID.value !== undefined) {
+        delete responses.value[selectedSurveyID.value];
+        delete questions.value[selectedSurveyID.value];
+        delete participants.value[selectedSurveyID.value];
+      }
+      selectedSurveyID.value = undefined;
+      minMaxFromDataset.value = {};
     }
 
     function reset() {

--- a/src/store/surveyStore.ts
+++ b/src/store/surveyStore.ts
@@ -196,13 +196,14 @@ export const useSurveyStore = defineStore(
     }
 
     async function refreshSurvey(surveyId: number): Promise<void> {
-      resetSurvey();
       if (!(surveyId in surveys.value)) {
         await refreshSurveys();
       }
 
       resetSurvey();
 
+      selectedSurveyID.value = surveyId;
+    
       await Promise.all([
         refreshQuestions(surveyId),
         refreshResponses(surveyId),
@@ -309,13 +310,13 @@ export const useSurveyStore = defineStore(
       responseRange.value = [0, new Date().getTime()];
       questionKeys.value = [];
       questionKeysWithSubquestions.value = [];
+      minMaxFromDataset.value = {};
+    
       if (selectedSurveyID.value !== undefined) {
         delete responses.value[selectedSurveyID.value];
         delete questions.value[selectedSurveyID.value];
         delete participants.value[selectedSurveyID.value];
       }
-      selectedSurveyID.value = undefined;
-      minMaxFromDataset.value = {};
     }
 
     function reset() {

--- a/src/store/surveyStore.ts
+++ b/src/store/surveyStore.ts
@@ -200,13 +200,9 @@ export const useSurveyStore = defineStore(
       if (!(surveyId in surveys.value)) {
         await refreshSurveys();
       }
-    
-      selectedSurveyID.value = surveyId;
-      
-      responses.value[surveyId] = [];
-      questions.value[surveyId] = {};
-      participants.value[surveyId] = [];
-      
+
+      resetSurvey();
+
       await Promise.all([
         refreshQuestions(surveyId),
         refreshResponses(surveyId),

--- a/src/views/SurveyView.vue
+++ b/src/views/SurveyView.vue
@@ -96,6 +96,7 @@ export default defineComponent({
         store.reset();
         await store.refreshSurvey(newVal);
       },
+      { immediate: true }
     );
 
     return {


### PR DESCRIPTION
When switching between surveys in the dashboard, questions and data from the previous survey were incorrectly persisting and mixing with the new survey's data. This occurred because of incomplete state cleanup when transitioning between surveys.

## Changes
- Modified `resetSurvey()` function to properly clear all survey-specific data including:
  - Question keys and subquestion arrays
  - Survey-specific responses, questions, and participants
  - Token mappings and dataset ranges
- Modified `refreshSurvey()` to ensure proper ordering of operations:
  - Complete state reset before loading new survey
  - Initialization of empty containers before data fetching
  - Proper handling of survey ID changes

