### PR TITLE
Improve candlestick visibility

### DIFF
--- a/src/components/surveys/CandlestickChart.vue
+++ b/src/components/surveys/CandlestickChart.vue
@@ -1,15 +1,14 @@
 <template>
-  <candle-chart v-if="renderChart" :data="chartjsData" :style="chartStyle" :options="chartOptions" />
+  <candle-chart v-if="renderChart" :data="processedChartData" :style="chartStyle" :options="chartOptions" :plugins="medianPlugins" />
 </template>
 
 <script lang="ts">
-import { Chart as ChartJS, ChartOptions, ChartData, FinancialDataPoint, TooltipItem } from "chart.js";
+import { Chart as ChartJS, ChartOptions, ChartData, FinancialDataPoint, TooltipItem, Plugin } from "chart.js";
 import { CandlestickController, CandlestickElement, OhlcController, OhlcElement } from "chartjs-chart-financial";
 import { createTypedChart } from "vue-chartjs";
 import { defineComponent, ref, onMounted, nextTick, computed, watch } from "vue";
 import "chartjs-adapter-moment";
 import { useSurveyStore } from "../../store/surveyStore";
-import "../../helpers/custom-ohlc-element";
 const CandleChart = createTypedChart("candlestick", CandlestickElement);
 
 ChartJS.register(CandlestickController, CandlestickElement, OhlcController, OhlcElement);
@@ -25,6 +24,39 @@ type CandlestickChartOptions = ChartOptions<"candlestick"> & {
       borderWidth?: number;
     };
   };
+};
+
+const medianLinesPlugin: Plugin = {
+  id: "medianLines",
+  afterDatasetsDraw: (chart) => {
+    const { ctx, chartArea, scales } = chart;
+    if (!scales.x || !scales.y || !chart.data.datasets[0]) return;
+
+    const dataset = chart.data.datasets[0];
+
+    ctx.save();
+    ctx.lineWidth = 1.5; 
+    ctx.strokeStyle = "rgba(0, 0, 0, 1)"; 
+    ctx.setLineDash([]); 
+
+    dataset.data.forEach((data: any) => {
+      if (!data || typeof data !== "object" || !("m" in data) || !("x" in data)) return;
+
+      const x = scales.x.getPixelForValue(data.x);
+      const y = scales.y.getPixelForValue(data.m);
+
+      if (x >= chartArea.left && x <= chartArea.right && y >= chartArea.top && y <= chartArea.bottom) {
+        const candleWidth = 8; 
+
+        ctx.beginPath();
+        ctx.moveTo(x - candleWidth / 2, y);
+        ctx.lineTo(x + candleWidth / 2, y);
+        ctx.stroke();
+      }
+    });
+
+    ctx.restore();
+  },
 };
 
 export default defineComponent({
@@ -50,12 +82,43 @@ export default defineComponent({
       height: "100%",
     };
 
+    const processedChartData = computed(() => {
+      if (!props.chartjsData || !props.chartjsData.datasets || props.chartjsData.datasets.length === 0) {
+        return props.chartjsData;
+      }
+
+      const newData = JSON.parse(JSON.stringify(props.chartjsData));
+
+      newData.datasets[0].data = newData.datasets[0].data.map((point: any) => {
+        if (point && typeof point === "object") {
+          const median = point.m;
+
+          return {
+            x: point.x,
+            o: point.o,
+            h: point.c, 
+            l: point.o, 
+            c: point.c,
+            m: median, 
+          };
+        }
+        return point;
+      });
+
+      return newData;
+    });
+
+    const medianPlugins = [medianLinesPlugin];
+
     watch(
       () => props.chartjsData,
       (newData) => {
         console.debug("Candlestick data updated:", newData);
         if (newData?.datasets?.length) {
           const dataset = newData.datasets[0];
+          if (dataset.data?.length > 0) {
+            console.debug("Sample data point:", dataset.data[0]);
+          }
         }
       },
       { deep: true, immediate: true },
@@ -63,7 +126,6 @@ export default defineComponent({
 
     const minmax = computed(() => {
       const result = store.minMaxFromDataset?.[props.questionKey];
-      console.debug("Min/max values for", props.questionKey, ":", result);
       return result;
     });
 
@@ -78,6 +140,16 @@ export default defineComponent({
       return {
         responsive: true,
         maintainAspectRatio: false,
+        elements: {
+          candlestick: {
+            color: {
+              up: "rgba(75, 192, 192, 1)",
+              down: "rgba(255, 99, 132, 1)",
+              unchanged: "rgba(50, 50, 50, 1)",
+            },
+            borderWidth: 1,
+          },
+        },
         scales: {
           x: {
             type: "time",
@@ -134,20 +206,21 @@ export default defineComponent({
             mode: "index" as const,
             callbacks: {
               label(ctx: TooltipItem<"candlestick">) {
-                const point = ctx.parsed as FinancialDataPoint;
-                return [`Low: ${point.l}`, `High: ${point.h}`, `Open: ${point.o}`, `Close: ${point.c}`];
+                const point = ctx.parsed as any;
+                const dataPoint = ctx.dataset.data[ctx.dataIndex] as any;
+                const hasMedian = dataPoint && typeof dataPoint === "object" && "m" in dataPoint;
+
+                const tooltipLabels = [];
+
+                if (hasMedian) {
+                  tooltipLabels.push(`Median: ${dataPoint.m}`);
+                }
+
+                tooltipLabels.push(`Open: ${point.o}`, `High: ${point.h}`, `Low: ${point.l}`, `Close: ${point.c}`);
+
+                return tooltipLabels;
               },
             },
-          },
-        },
-        elements: {
-          candlestick: {
-            color: {
-              up: "rgba(75, 192, 192, 1)",
-              down: "rgba(255, 99, 132, 1)",
-              unchanged: "rgba(50, 50, 50, 1)",
-            },
-            borderWidth: 1.5,
           },
         },
         layout: {
@@ -170,7 +243,7 @@ export default defineComponent({
       }
     });
 
-    return { chartStyle, renderChart, chartOptions };
+    return { chartStyle, renderChart, chartOptions, medianPlugins, processedChartData };
   },
 });
 </script>

--- a/src/components/surveys/CandlestickChart.vue
+++ b/src/components/surveys/CandlestickChart.vue
@@ -26,7 +26,7 @@ CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
   const options = this.options || {};
   const valueChange = close - open;
   const isPositive = valueChange >= 0;
-  
+
   const customColors = options.color || {};
 
   if (isFlat) {
@@ -63,10 +63,10 @@ type CandlestickChartOptions = ChartOptions<"candlestick"> & {
 };
 
 interface ExtendedFinancialDataPoint extends FinancialDataPoint {
-  m: number;        
-  a: number;       
-  count: number;    
-  tokens: string[]; 
+  m: number;
+  a: number;
+  count: number;
+  tokens: string[];
 }
 
 const medianLinesPlugin: Plugin = {
@@ -78,9 +78,9 @@ const medianLinesPlugin: Plugin = {
     const dataset = chart.data.datasets[0];
 
     ctx.save();
-    ctx.lineWidth = 1.5; 
-    ctx.strokeStyle = "rgba(0, 0, 0, 1)"; 
-    ctx.setLineDash([]); 
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = "rgba(0, 0, 0, 1)";
+    ctx.setLineDash([]);
 
     dataset.data.forEach((data: any) => {
       if (!data || typeof data !== "object" || !("m" in data) || !("x" in data)) return;
@@ -89,7 +89,7 @@ const medianLinesPlugin: Plugin = {
       const y = scales.y.getPixelForValue(data.m);
 
       if (x >= chartArea.left && x <= chartArea.right && y >= chartArea.top && y <= chartArea.bottom) {
-        const candleWidth = 8; 
+        const candleWidth = 8;
 
         ctx.beginPath();
         ctx.moveTo(x - candleWidth / 2, y);
@@ -101,7 +101,6 @@ const medianLinesPlugin: Plugin = {
     ctx.restore();
   },
 };
-
 
 const averageLinePlugin: Plugin = {
   id: "averageLine",
@@ -143,35 +142,42 @@ const enhancedColorPlugin: Plugin = {
     if (!scales.x || !scales.y || !chart.data.datasets[0]) return;
 
     const dataset = chart.data.datasets[0];
-    
+
     let maxCount = 0;
     dataset.data.forEach((data: any) => {
       if (data && typeof data === "object" && "count" in data) {
         maxCount = Math.max(maxCount, data.count);
       }
     });
-    
+
     if (maxCount === 0) return;
-    
+
     dataset.data.forEach((data: any, index: number) => {
       if (!data || typeof data !== "object" || !("count" in data)) return;
-      
+
       const intensity = data.count / maxCount;
-      const alpha = 0.3 + (intensity * 0.7); 
-      
+      const alpha = 0.3 + intensity * 0.7;
+
       const valueChange = data.c - data.o;
-      
+
       const element = chart.getDatasetMeta(0).data[index];
       if (element) {
         element.options = element.options || {};
         element.options.color = {
-          up: `rgba(75, 192, 192, ${alpha})`,     
-          down: `rgba(255, 99, 132, ${alpha})`,   
-          unchanged: `rgba(150, 150, 150, ${alpha})` 
+          up: `rgba(75, 192, 192, ${alpha})`,
+          down: `rgba(255, 99, 132, ${alpha})`,
+          unchanged: `rgba(150, 150, 150, ${alpha})`,
         };
       }
     });
-  }
+  },
+};
+
+const fontConfig = {
+  titleSize: 16,
+  axisTitleSize: 14,
+  tickLabelSize: 12,
+  tooltipSize: 13,
 };
 
 export default defineComponent({
@@ -232,16 +238,17 @@ export default defineComponent({
     };
 
     const formatTooltipTitle = (items: any[]) => {
-      if (!items || items.length === 0) return '';
+      if (!items || items.length === 0) return "";
       const date = new Date(items[0].parsed.x);
-      return date.toLocaleDateString('en-US', { 
-        weekday: 'short', 
-        year: 'numeric', 
-        month: 'short', 
-        day: 'numeric',
+      return date.toLocaleDateString("en-US", {
+        weekday: "short",
+        year: "numeric",
+        month: "short",
+        day: "numeric",
       });
     };
 
+    // Updated chartOptions to exactly match the structure in line-options.ts
     const chartOptions = computed((): CandlestickChartOptions => {
       return {
         responsive: true,
@@ -258,32 +265,24 @@ export default defineComponent({
         },
         scales: {
           x: {
+            offset: true,
             type: "time",
             time: {
-              unit: "month", 
-              displayFormats: {
-                month: "MMM YYYY"
-              },
-              tooltipFormat: 'MMM D, YYYY'
+              unit: "day",
             },
             title: {
               display: true,
               text: "Date",
-              font: { size: 12, weight: "bold" },
-              padding: { top: 5 },
-            },
-            adapters: {
-              date: {
-                locale: "en",
+              font: {
+                size: fontConfig.axisTitleSize,
+                weight: "bold",
               },
             },
             ticks: {
-              font: { size: 10 },
-              maxRotation: 0,
-              autoSkip: true,
-              maxTicksLimit: 6, 
+              font: {
+                size: fontConfig.tickLabelSize,
+              },
             },
-            grid: { display: true, color: "rgba(0,0,0,0.05)" },
           },
           y: {
             min: minmax.value?.min || 0,
@@ -291,25 +290,39 @@ export default defineComponent({
             title: {
               display: true,
               text: "Value",
-              font: { size: 12, weight: "bold" },
-              padding: { bottom: 5 },
+              font: {
+                size: fontConfig.axisTitleSize,
+                weight: "bold",
+              },
             },
             ticks: {
-              font: { size: 10 },
-              maxTicksLimit: 10,
+              font: {
+                size: fontConfig.tickLabelSize,
+              },
               callback: formatYAxisTick,
-              padding: 8,
             },
-            grid: { color: "rgba(0, 0, 0, 0.05)" },
           },
         },
         plugins: {
+          title: {
+            display: true,
+            text: "",
+            padding: 20,
+            font: {
+              size: fontConfig.titleSize,
+              weight: "bold",
+            },
+          },
           legend: {
             display: false,
           },
           tooltip: {
-            titleFont: { size: 12 },
-            bodyFont: { size: 11 },
+            titleFont: {
+              size: fontConfig.tooltipSize,
+            },
+            bodyFont: {
+              size: fontConfig.tooltipSize,
+            },
             intersect: false,
             mode: "index" as const,
             displayColors: false,
@@ -318,61 +331,60 @@ export default defineComponent({
               label(ctx: TooltipItem<"candlestick">) {
                 const point = ctx.parsed as any;
                 const dataPoint = ctx.dataset.data[ctx.dataIndex] as any;
-                
+
                 const tooltipLabels = [];
-                
+
                 const date = new Date(dataPoint.x);
-                tooltipLabels.push(`Date: ${date.toLocaleDateString('en-US', { 
-                  weekday: 'long', 
-                  year: 'numeric', 
-                  month: 'long', 
-                  day: 'numeric'
-                })}`);
-                
+                tooltipLabels.push(
+                  `Date: ${date.toLocaleDateString("en-US", {
+                    weekday: "long",
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}`,
+                );
+
                 tooltipLabels.push(`Active responses: ${dataPoint.count}`);
-                
-                if ('m' in dataPoint) {
+
+                if ("m" in dataPoint) {
                   tooltipLabels.push(`Median: ${dataPoint.m.toFixed(2)}`);
                 }
-                
-                if ('a' in dataPoint) {
+
+                if ("a" in dataPoint) {
                   tooltipLabels.push(`Average: ${dataPoint.a.toFixed(2)}`);
                 }
-                
+
                 tooltipLabels.push(
                   `Range: ${point.l.toFixed(2)} - ${point.h.toFixed(2)}`,
                   `First: ${point.o.toFixed(2)}`,
                   `Last: ${point.c.toFixed(2)}`,
-                  `Change: ${(point.c - point.o).toFixed(2)}`
+                  `Change: ${(point.c - point.o).toFixed(2)}`,
                 );
-                
+
                 if (dataPoint.tokens && dataPoint.tokens.length > 0) {
-                  tooltipLabels.push('');
-                  tooltipLabels.push('Active participants:');
+                  tooltipLabels.push("");
+                  tooltipLabels.push("Active participants:");
                   const maxParticipantsToShow = 5;
                   const participants = dataPoint.tokens.slice(0, maxParticipantsToShow).map((token: string) => {
                     return getParticipant(token);
                   });
-                  
+
                   tooltipLabels.push(...participants);
-                  
+
                   if (dataPoint.tokens.length > maxParticipantsToShow) {
                     tooltipLabels.push(`...and ${dataPoint.tokens.length - maxParticipantsToShow} more`);
                   }
                 }
-                
+
                 return tooltipLabels;
               },
             },
           },
         },
-        layout: {
-          padding: {
-            left: 5,
-            right: 15,
-            top: 20,
-            bottom: 10,
-          },
+        interaction: {
+          mode: "nearest",
+          axis: "x",
+          intersect: false,
         },
       };
     });

--- a/src/components/surveys/CandlestickChart.vue
+++ b/src/components/surveys/CandlestickChart.vue
@@ -3,15 +3,16 @@
 </template>
 
 <script lang="ts">
-import { Chart as ChartJS, ChartOptions, ChartData, FinancialDataPoint } from "chart.js";
+import { Chart as ChartJS, ChartOptions, ChartData, FinancialDataPoint, TooltipItem } from "chart.js";
 import { CandlestickController, CandlestickElement, OhlcController, OhlcElement } from "chartjs-chart-financial";
 import { createTypedChart } from "vue-chartjs";
 import { defineComponent, ref, onMounted, nextTick, computed, watch } from "vue";
 import "chartjs-adapter-moment";
 import { useSurveyStore } from "../../store/surveyStore";
-ChartJS.register(CandlestickController, CandlestickElement, OhlcController, OhlcElement);
-
+import "../../helpers/custom-ohlc-element";
 const CandleChart = createTypedChart("candlestick", CandlestickElement);
+
+ChartJS.register(CandlestickController, CandlestickElement, OhlcController, OhlcElement);
 
 type CandlestickChartOptions = ChartOptions<"candlestick"> & {
   elements?: {
@@ -21,6 +22,7 @@ type CandlestickChartOptions = ChartOptions<"candlestick"> & {
         down?: string;
         unchanged?: string;
       };
+      borderWidth?: number;
     };
   };
 };
@@ -52,15 +54,8 @@ export default defineComponent({
       () => props.chartjsData,
       (newData) => {
         console.debug("Candlestick data updated:", newData);
-        if (newData && newData.datasets) {
-          console.debug("Dataset count:", newData.datasets.length);
-
-          if (newData.datasets.length > 0) {
-            const dataset = newData.datasets[0];
-            console.debug("Dataset label:", dataset.label);
-            console.debug("Data points count:", dataset.data?.length || 0);
-            console.debug("First 3 data points:", JSON.stringify(dataset.data?.slice(0, 3)));
-          }
+        if (newData?.datasets?.length) {
+          const dataset = newData.datasets[0];
         }
       },
       { deep: true, immediate: true },
@@ -80,7 +75,7 @@ export default defineComponent({
     };
 
     const chartOptions = computed((): CandlestickChartOptions => {
-      const options: CandlestickChartOptions = {
+      return {
         responsive: true,
         maintainAspectRatio: false,
         scales: {
@@ -95,13 +90,8 @@ export default defineComponent({
             title: {
               display: true,
               text: "Date",
-              font: {
-                size: 10,
-                weight: "bold",
-              },
-              padding: {
-                top: 0,
-              },
+              font: { size: 10, weight: "bold" },
+              padding: { top: 0 },
             },
             adapters: {
               date: {
@@ -109,15 +99,11 @@ export default defineComponent({
               },
             },
             ticks: {
-              font: {
-                size: 9,
-              },
+              font: { size: 9 },
               maxRotation: 0,
               maxTicksLimit: 8,
             },
-            grid: {
-              display: false,
-            },
+            grid: { display: false },
           },
           y: {
             min: minmax.value?.min || 0,
@@ -125,25 +111,16 @@ export default defineComponent({
             title: {
               display: true,
               text: "Value",
-              font: {
-                size: 10,
-                weight: "bold",
-              },
-              padding: {
-                bottom: 0,
-              },
+              font: { size: 10, weight: "bold" },
+              padding: { bottom: 0 },
             },
             ticks: {
-              font: {
-                size: 9,
-              },
+              font: { size: 9 },
               maxTicksLimit: 5,
               callback: formatYAxisTick,
               padding: 8,
             },
-            grid: {
-              color: "rgba(0, 0, 0, 0.05)",
-            },
+            grid: { color: "rgba(0, 0, 0, 0.05)" },
           },
         },
         plugins: {
@@ -151,16 +128,12 @@ export default defineComponent({
             display: false,
           },
           tooltip: {
-            titleFont: {
-              size: 11,
-            },
-            bodyFont: {
-              size: 11,
-            },
+            titleFont: { size: 11 },
+            bodyFont: { size: 11 },
             intersect: false,
-            mode: "index",
+            mode: "index" as const,
             callbacks: {
-              label(ctx) {
+              label(ctx: TooltipItem<"candlestick">) {
                 const point = ctx.parsed as FinancialDataPoint;
                 return [`Low: ${point.l}`, `High: ${point.h}`, `Open: ${point.o}`, `Close: ${point.c}`];
               },
@@ -172,53 +145,26 @@ export default defineComponent({
             color: {
               up: "rgba(75, 192, 192, 1)",
               down: "rgba(255, 99, 132, 1)",
-              unchanged: "rgba(90, 90, 90, 1)",
+              unchanged: "rgba(50, 50, 50, 1)",
             },
+            borderWidth: 1.5,
           },
         },
         layout: {
           padding: {
             left: 2,
             right: 10,
-            top: 8,
+            top: 20,
             bottom: 10,
           },
         },
       };
-
-      console.debug(
-        "Candlestick chart options:",
-        JSON.stringify({
-          scales: {
-            x: options.scales?.x?.type,
-            y: { min: options.scales?.y?.min, max: options.scales?.y?.max },
-          },
-          plugins: Object.keys(options.plugins || {}),
-          elements: options.elements ? Object.keys(options.elements) : [],
-        }),
-      );
-
-      return options;
     });
 
     onMounted(async () => {
       try {
         await nextTick();
-        console.debug("About to render candlestick chart");
         renderChart.value = true;
-        console.debug("Candlestick chart render triggered");
-        console.debug(
-          "Chart mounted with data structure:",
-          JSON.stringify({
-            datasets: props.chartjsData.datasets
-              ? props.chartjsData.datasets.map((d) => ({
-                  label: d.label,
-                  dataLength: d.data?.length || 0,
-                  samplePoints: d.data?.slice(0, 2) || [],
-                }))
-              : [],
-          }),
-        );
       } catch (error) {
         console.error("Error rendering candlestick chart:", error);
       }

--- a/src/components/surveys/ChartCard.vue
+++ b/src/components/surveys/ChartCard.vue
@@ -4,8 +4,15 @@
       <v-row class="chartrow align-stretch">
         <v-col cols="12" class="px-3 py-2">
           <v-card-title class="px-0 py-1">
-            <span class="question-id">{{ questionKey }} – </span>
-            <span class="question-title">{{ questionText }}</span>
+            <v-tooltip location="top">
+              <template #activator="{ props }">
+                <span v-bind="props">
+                  <span class="question-id">{{ questionKey }} – </span>
+                  <span class="question-title">{{ questionText }}</span>
+                </span>
+              </template>
+              <span>Question type: {{ questionType }}</span>
+            </v-tooltip>
           </v-card-title>
         </v-col>
         <v-col cols="12" class="d-flex flex-wrap pt-0 pb-3">

--- a/src/components/surveys/HistogramChart.vue
+++ b/src/components/surveys/HistogramChart.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="chart-container">
-    <Bar :data="chartData" :options="chartOptions" />
+    <div v-if="!hasData" class="no-data-message">
+      <p>{{ noDataMessage }}</p>
+    </div>
+    <Bar v-else :data="chartData" :options="chartOptions" />
   </div>
 </template>
 
@@ -30,8 +33,16 @@ export default defineComponent({
     },
   },
   setup(props) {
+    const hasData = computed((): boolean => {
+      return props.chartjsData?.datasets?.[0]?.data?.length > 0;
+    });
+
+    const noDataMessage = computed((): string => {
+      return props.chartjsData?.title || "Not enough data to display histogram";
+    });
+
     const chartData = computed((): ChartData<"bar"> => {
-      if (!props.chartjsData || !props.chartjsData.datasets) {
+      if (!hasData.value) {
         return { labels: [], datasets: [] };
       }
 
@@ -42,7 +53,7 @@ export default defineComponent({
     });
 
     const totalResponses = computed((): number => {
-      if (!props.chartjsData || !props.chartjsData.datasets || !props.chartjsData.datasets[0]) {
+      if (!hasData.value) {
         return 0;
       }
 
@@ -134,6 +145,8 @@ export default defineComponent({
     return {
       chartData,
       chartOptions,
+      hasData,
+      noDataMessage,
     };
   },
 });
@@ -144,5 +157,14 @@ export default defineComponent({
   height: 100%;
   width: 100%;
   padding: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.no-data-message {
+  text-align: center;
+  color: #666;
+  font-style: italic;
 }
 </style>

--- a/src/components/surveys/HistogramChart.vue
+++ b/src/components/surveys/HistogramChart.vue
@@ -136,6 +136,8 @@ export default defineComponent({
               font: {
                 size: 10,
               },
+              minRotation: 0,
+              maxRotation: 0,
             },
           },
         },

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -78,8 +78,7 @@ export function createActiveNumericalData(questionKey: string): HistogramChartDa
 
   if (store.settings.onlyActive) {
     return getActiveHistogramData(filteredResponsesNA, questionKey);
-  }
-  else {
+  } else {
     return getHistogramData(filteredResponsesNA, questionKey);
   }
 }

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -2,7 +2,7 @@ import { ChartData, ChartDataset } from "chart.js";
 import { useSurveyStore } from "../store/surveyStore";
 import { responseCount, FilteredResponse } from "../types/response.model";
 import { isNumericalQuestion, isYesNoQuestion, isMultipleChoiceQuestion } from "./questionMapping";
-import { getHistogramData, getAverageLineChart, setMinMaxFromDataset, getOHLC } from "./numerical-charts";
+import { getHistogramData, getAverageLineChart, setMinMaxFromDataset, getActiveHistogramData, getOHLC } from "./numerical-charts";
 import { parseDataForAreaChart, transformChartData } from "./yesno-charts";
 import { addExpiredEntries, getBorderColor } from "./shared-chartFunctions";
 import { parseDataForFreeTextChart } from "./freetext-charts";
@@ -75,9 +75,13 @@ export function createActiveNumericalData(questionKey: string): HistogramChartDa
   const store = useSurveyStore();
   const allResponses = store.getFilteredResponses(questionKey);
   const filteredResponsesNA = filterNA(allResponses);
-  const activeResponses = getLastResponses(filteredResponsesNA);
 
-  return getHistogramData(activeResponses, questionKey);
+  if (store.settings.onlyActive) {
+    return getActiveHistogramData(filteredResponsesNA, questionKey);
+  }
+  else {
+    return getHistogramData(filteredResponsesNA, questionKey);
+  }
 }
 
 export function getLastResponses(responses: FilteredResponse[]): FilteredResponse[] {
@@ -161,7 +165,6 @@ export function aggregateResponses(data: FilteredResponse[]): FilteredResponse[]
 
   const { step } = store.settings;
 
-  // if there are multiple responses from the same token withing step hours of time aggregate them
   data.forEach((item) => {
     const lastResponse = aggregatedData.find(
       (response) => response.token === item.token && response.time.getTime() + step * 60 * 60 * 1000 > item.time.getTime(),

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -5,26 +5,24 @@ const originalDraw = CandlestickElementPrototype.draw;
 
 CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
   const { open, high, low, close, x, width, y } = this;
-
   const isFlat = open === high && high === low && low === close;
 
   if (isFlat) {
     ctx.save();
-
     ctx.strokeStyle = "rgba(75, 192, 192, 1)";
     ctx.fillStyle = "rgba(75, 192, 192, 0.2)";
     ctx.lineWidth = 1.5;
-
     const minHeight = 5;
     const yTop = y - minHeight / 2;
-
     ctx.beginPath();
     ctx.rect(x - width / 2, yTop, width, minHeight);
     ctx.fill();
     ctx.stroke();
-
     ctx.restore();
   } else {
     originalDraw.call(this, ctx);
   }
+
 };
+
+const OhlcElementPrototype = (FinancialElements.OhlcElement as any).prototype;

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -22,7 +22,6 @@ CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
   } else {
     originalCandleDraw.call(this, ctx);
   }
-
 };
 
 const OhlcElementPrototype = (FinancialElements.OhlcElement as any).prototype;
@@ -36,9 +35,9 @@ OhlcElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
   if ((this as any).count !== undefined) {
     const count = (this as any).count;
     ctx.save();
-    ctx.font = '10px Arial';
-    ctx.textAlign = 'center';
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.font = "10px Arial";
+    ctx.textAlign = "center";
+    ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
     ctx.fillText(`n=${count}`, x, this._yScale.getPixelForValue(high) - 10);
     ctx.restore();
   }

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -1,0 +1,30 @@
+import * as FinancialElements from "chartjs-chart-financial";
+
+const CandlestickElementPrototype = (FinancialElements.CandlestickElement as any).prototype;
+const originalDraw = CandlestickElementPrototype.draw;
+
+CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
+    const { open, high, low, close, x, width, y } = this;
+
+    const isFlat = open === high && high === low && low === close;
+
+    if (isFlat) {
+        ctx.save();
+
+        ctx.strokeStyle = "rgba(75, 192, 192, 1)";
+        ctx.fillStyle = "rgba(75, 192, 192, 0.2)";
+        ctx.lineWidth = 1.5;
+
+        const minHeight = 5;
+        const yTop = y - minHeight / 2;
+
+        ctx.beginPath();
+        ctx.rect(x - width / 2, yTop, width, minHeight);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.restore();
+    } else {
+        originalDraw.call(this, ctx);
+    }
+};

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -1,7 +1,7 @@
 import * as FinancialElements from "chartjs-chart-financial";
 
 const CandlestickElementPrototype = (FinancialElements.CandlestickElement as any).prototype;
-const originalDraw = CandlestickElementPrototype.draw;
+const originalCandleDraw = CandlestickElementPrototype.draw;
 
 CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
   const { open, high, low, close, x, width, y } = this;
@@ -20,9 +20,26 @@ CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
     ctx.stroke();
     ctx.restore();
   } else {
-    originalDraw.call(this, ctx);
+    originalCandleDraw.call(this, ctx);
   }
 
 };
 
 const OhlcElementPrototype = (FinancialElements.OhlcElement as any).prototype;
+const originalOhlcDraw = OhlcElementPrototype.draw;
+
+OhlcElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
+  originalOhlcDraw.call(this, ctx);
+
+  const { x, open, high, low, close } = this;
+
+  if ((this as any).count !== undefined) {
+    const count = (this as any).count;
+    ctx.save();
+    ctx.font = '10px Arial';
+    ctx.textAlign = 'center';
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+    ctx.fillText(`n=${count}`, x, this._yScale.getPixelForValue(high) - 10);
+    ctx.restore();
+  }
+};

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -4,27 +4,27 @@ const CandlestickElementPrototype = (FinancialElements.CandlestickElement as any
 const originalDraw = CandlestickElementPrototype.draw;
 
 CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
-    const { open, high, low, close, x, width, y } = this;
+  const { open, high, low, close, x, width, y } = this;
 
-    const isFlat = open === high && high === low && low === close;
+  const isFlat = open === high && high === low && low === close;
 
-    if (isFlat) {
-        ctx.save();
+  if (isFlat) {
+    ctx.save();
 
-        ctx.strokeStyle = "rgba(75, 192, 192, 1)";
-        ctx.fillStyle = "rgba(75, 192, 192, 0.2)";
-        ctx.lineWidth = 1.5;
+    ctx.strokeStyle = "rgba(75, 192, 192, 1)";
+    ctx.fillStyle = "rgba(75, 192, 192, 0.2)";
+    ctx.lineWidth = 1.5;
 
-        const minHeight = 5;
-        const yTop = y - minHeight / 2;
+    const minHeight = 5;
+    const yTop = y - minHeight / 2;
 
-        ctx.beginPath();
-        ctx.rect(x - width / 2, yTop, width, minHeight);
-        ctx.fill();
-        ctx.stroke();
+    ctx.beginPath();
+    ctx.rect(x - width / 2, yTop, width, minHeight);
+    ctx.fill();
+    ctx.stroke();
 
-        ctx.restore();
-    } else {
-        originalDraw.call(this, ctx);
-    }
+    ctx.restore();
+  } else {
+    originalDraw.call(this, ctx);
+  }
 };

--- a/src/helpers/custom-ohlc-element.ts
+++ b/src/helpers/custom-ohlc-element.ts
@@ -1,11 +1,51 @@
 import * as FinancialElements from "chartjs-chart-financial";
 
-const CandlestickElementPrototype = (FinancialElements.CandlestickElement as any).prototype;
+interface CustomCandlestickElement {
+  open: number;
+  close: number;
+  high: number;
+  low: number;
+  x: number;
+  y: number;
+  width: number;
+  options?: {
+    color?: {
+      up?: string;
+      down?: string;
+      unchanged?: string;
+    };
+  };
+  draw: (ctx: CanvasRenderingContext2D) => void;
+}
+
+interface CustomOhlcElement {
+  open: number;
+  close: number;
+  high: number;
+  low: number;
+  x: number;
+  _yScale: {
+    getPixelForValue: (val: number) => number;
+  };
+  count?: number;
+  draw: (ctx: CanvasRenderingContext2D) => void;
+}
+
+const CandlestickElementPrototype = (
+  FinancialElements.CandlestickElement as unknown as {
+    prototype: CustomCandlestickElement;
+  }
+).prototype;
+
 const originalCandleDraw = CandlestickElementPrototype.draw;
 
-CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
+CandlestickElementPrototype.draw = function (this: CustomCandlestickElement, ctx: CanvasRenderingContext2D) {
   const { open, high, low, close, x, width, y } = this;
   const isFlat = open === high && high === low && low === close;
+
+  const options = this.options || {};
+  const isPositive = close - open >= 0;
+  const customColors = options.color || {};
 
   if (isFlat) {
     ctx.save();
@@ -20,25 +60,30 @@ CandlestickElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
     ctx.stroke();
     ctx.restore();
   } else {
+    if (customColors.up && customColors.down) {
+      this.options!.color = isPositive ? { up: customColors.up } : { down: customColors.down };
+    }
     originalCandleDraw.call(this, ctx);
   }
 };
 
-const OhlcElementPrototype = (FinancialElements.OhlcElement as any).prototype;
+const OhlcElementPrototype = (
+  FinancialElements.OhlcElement as unknown as {
+    prototype: CustomOhlcElement;
+  }
+).prototype;
+
 const originalOhlcDraw = OhlcElementPrototype.draw;
 
-OhlcElementPrototype.draw = function (ctx: CanvasRenderingContext2D) {
+OhlcElementPrototype.draw = function (this: CustomOhlcElement, ctx: CanvasRenderingContext2D) {
   originalOhlcDraw.call(this, ctx);
 
-  const { x, open, high, low, close } = this;
-
-  if ((this as any).count !== undefined) {
-    const count = (this as any).count;
+  if (this.count !== undefined) {
     ctx.save();
     ctx.font = "10px Arial";
     ctx.textAlign = "center";
     ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
-    ctx.fillText(`n=${count}`, x, this._yScale.getPixelForValue(high) - 10);
+    ctx.fillText(`n=${this.count}`, this.x, this._yScale.getPixelForValue(this.high) - 10);
     ctx.restore();
   }
 };

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -63,7 +63,7 @@ export function getActiveHistogramData(data: FilteredResponse[], questionKey: st
 
   const latestResponsesByToken: Record<string, FilteredResponse> = {};
 
-  sortedData.forEach(response => {
+  sortedData.forEach((response) => {
     if (!isResponseActive(response, endDate, expirationDays)) return;
 
     const existing = latestResponsesByToken[response.token];
@@ -73,7 +73,7 @@ export function getActiveHistogramData(data: FilteredResponse[], questionKey: st
   });
 
   const values: number[] = [];
-  Object.values(latestResponsesByToken).forEach(resp => {
+  Object.values(latestResponsesByToken).forEach((resp) => {
     const v = Number(resp.answer);
     if (!isNaN(v)) values.push(v);
   });
@@ -100,10 +100,10 @@ export function getActiveHistogramData(data: FilteredResponse[], questionKey: st
   const shortTitle = questionText.length > 40 ? questionText.substring(0, 40) + "..." : questionText;
 
   return {
-    labels: binData.map(b => b.label),
+    labels: binData.map((b) => b.label),
     datasets: [
       {
-        data: binData.map(b => b.count),
+        data: binData.map((b) => b.count),
         backgroundColor: "rgba(75, 192, 192, 0.6)",
         borderColor: "rgba(75, 192, 192, 1)",
         borderWidth: 1,
@@ -111,7 +111,7 @@ export function getActiveHistogramData(data: FilteredResponse[], questionKey: st
         barPercentage: 0.95,
         categoryPercentage: 0.95,
         originalData: binData,
-      }
+      },
     ],
     title: shortTitle,
     subtitle: `${Object.keys(latestResponsesByToken).length} participants, ${values.length} responses`,
@@ -152,7 +152,7 @@ function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[
       if (isResponseActive(response, currentDate, expirationDays)) {
         const value = Number(response.answer);
         if (!isNaN(value)) {
-          const existingIndex = activeResponses.findIndex(r => r.token === response.token);
+          const existingIndex = activeResponses.findIndex((r) => r.token === response.token);
           if (existingIndex >= 0) {
             if (response.time > activeResponses[existingIndex].time) {
               activeResponses[existingIndex] = response;
@@ -166,7 +166,7 @@ function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[
     }
 
     if (activeResponses.length > 0) {
-      const values = activeResponses.map(r => Number(r.answer)).filter(v => !isNaN(v));
+      const values = activeResponses.map((r) => Number(r.answer)).filter((v) => !isNaN(v));
 
       if (values.length > 0) {
         aggregatedData[dateKey] = {
@@ -176,7 +176,7 @@ function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[
           highValue: Math.max(...values),
           values: values,
           average: values.reduce((sum, val) => sum + val, 0) / values.length,
-          tokens: Array.from(activeTokens)
+          tokens: Array.from(activeTokens),
         };
       }
     }
@@ -246,7 +246,7 @@ export function getOHLC(data: FilteredResponse[], questionKey: string): ChartDat
       m: +Number(median).toFixed(1),
       a: +Number(item.average).toFixed(1),
       count: item.tokens.length,
-      tokens: item.tokens
+      tokens: item.tokens,
     };
 
     datasets.push(point);

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -538,7 +538,7 @@ function createOptimalBins(values: number[], maxBins = 10): { min: number; max: 
   const max = Math.max(...values);
 
   if (min === max) {
-    return [{ min, max, label: `${min}` }];
+    return [{ min, max, label: `${min.toFixed(2)} - ${max.toFixed(2)}` }];
   }
 
   let binWidth = calculateFDRule(values);
@@ -560,14 +560,10 @@ function createOptimalBins(values: number[], maxBins = 10): { min: number; max: 
   const bins = [];
   for (let i = 0; i < numBins; i++) {
     const binMin = min + i * binWidth;
-    const binMax = i === numBins - 1 ? max : min + (i + 1) * binWidth;
-    const isInteger = values.every((v) => Math.floor(v) === v);
-    const binMinFormatted = isInteger ? Math.floor(binMin) : binMin.toFixed(1);
-    let binMaxFormatted = isInteger ? Math.ceil(binMax) : binMax.toFixed(1);
+    const binMax = binMin + binWidth;
 
-    if (i === numBins - 1) {
-      binMaxFormatted = isInteger ? Math.ceil(max) : max.toFixed(1);
-    }
+    const binMinFormatted = binMin.toFixed(2);
+    const binMaxFormatted = (binMax - 0.01).toFixed(2);
 
     bins.push({
       min: binMin,
@@ -578,6 +574,7 @@ function createOptimalBins(values: number[], maxBins = 10): { min: number; max: 
 
   return bins;
 }
+
 export function getAverageLineChart(data: FilteredResponse[], questionKey?: string): ChartData<"line"> {
   const store = useSurveyStore();
   const stepHours = store.settings.step || 24;

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,9 @@ import store from "./store/surveyStore";
 import router from "./router";
 import vuetify from "./plugins/vuetify";
 import "@mdi/font/css/materialdesignicons.css";
+import "chart.js/auto";
+import "chartjs-chart-financial";
+import "./helpers/custom-ohlc-element";
 
 const app = createApp(App);
 


### PR DESCRIPTION
This PR introduces a visual enhancement for flat candlestick elements, where all OHLC values are equal. These candles were previously difficult to see due to their zero height.
Changes:
Patched CandlestickElement.draw() to:
- Detect flat candles
- Render them as wider boxes with a minimum visible height
- No changes to regular candlestick behavior

Active Response Filtering:
- Candlesticks now only displays active (non-expired) responses
- Shows only the most recent response per participant per day
- Better tooltip information showing date, counts, statistics, and participants

![image](https://github.com/user-attachments/assets/d28f6925-c423-460c-b6c2-115af795f852)
