### PR TITLE
Fix histogram overcounting

### DIFF
--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -75,7 +75,7 @@ export function createActiveNumericalData(questionKey: string): HistogramChartDa
   const store = useSurveyStore();
   const allResponses = store.getFilteredResponses(questionKey);
   const filteredResponsesNA = filterNA(allResponses);
-  const activeResponses = store.settings.onlyActive ? getLastResponses(filteredResponsesNA) : filteredResponsesNA;
+  const activeResponses = getLastResponses(filteredResponsesNA);
 
   return getHistogramData(activeResponses, questionKey);
 }

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -355,13 +355,20 @@ export function getHistogramData(data: FilteredResponse[], questionKey: string):
 
   const binLabels = bucketsFromResponses(data);
 
-  const binCounts = binLabels.map((label) => {
+  const binCounts = binLabels.map((label, index) => {
     let count = 0;
     const roundedValues = values.map((val) => Math.round(val));
     const parsedBin = parseBinLabel(label);
 
     if (parsedBin) {
-      count = roundedValues.filter((val) => val >= parsedBin.min && val <= parsedBin.max).length;
+      const isLastBin = index === binLabels.length - 1;
+
+      count = roundedValues.filter((val) => {
+        if (parsedBin.min === parsedBin.max) {
+          return val === parsedBin.min;
+        }
+        return isLastBin ? val >= parsedBin.min && val <= parsedBin.max : val >= parsedBin.min && val < parsedBin.max;
+      }).length;
     }
 
     return {
@@ -374,6 +381,7 @@ export function getHistogramData(data: FilteredResponse[], questionKey: string):
 
   const questionText = getQuestionText(questionKey);
   const shortTitle = questionText.length > 40 ? questionText.substring(0, 40) + "..." : questionText;
+
   return {
     labels: binCounts.map((item) => item.label),
     datasets: [


### PR DESCRIPTION
The histogram was displaying more responses than actually exist because of overlapping bin definitions. 
I updated the binning logic in getHistogramData() to make upper bounds exclusive ([min, max)) for all bins except the last, which remains inclusive. This makes sure each response is counted in only one bin and fixes our issue.