### PR TITLE
Correct time slider filtering for candlestick charts 

### DIFF
--- a/src/components/TimeSlider.vue
+++ b/src/components/TimeSlider.vue
@@ -19,17 +19,9 @@ export default defineComponent({
 
     const { settings, getMinResponseDate, getMaxResponseDate, responseRange } = storeToRefs(store);
 
-    const minValue = ref(Math.round(getMidnight(getMinResponseDate.value).getTime()));
-    const maxValue = ref(Math.round(getMidnightTomrrow(getMaxResponseDate.value).getTime()));
+    const minValue = ref(Math.round(getMinResponseDate.value.getTime()));
+    const maxValue = ref(Math.round(getMaxResponseDate.value.getTime()));
     const stepSize = ref(settings.value.step * 60 * 1000);
-
-    function getMidnight(date: Date): Date {
-      return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-    }
-
-    function getMidnightTomrrow(date: Date): Date {
-      return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate() + 1));
-    }
 
     return {
       responseRange,

--- a/src/components/surveys/ChartCard.vue
+++ b/src/components/surveys/ChartCard.vue
@@ -7,7 +7,7 @@
             <v-tooltip location="top">
               <template #activator="{ props }">
                 <span v-bind="props">
-                  <span class="question-id">{{ questionKey }} – </span>
+                  <span class="question-id">{{ questionKey }} â€“ </span>
                   <span class="question-title">{{ questionText }}</span>
                 </span>
               </template>
@@ -106,8 +106,13 @@ export default defineComponent({
     });
 
     const numericChartData = computed(() => {
+      const timestamp = new Date().toISOString();
+      const rangeEnd = store.responseRange[1];
+      const ud = rangeEnd !== undefined ? new Date(rangeEnd) : store.getMaxResponseDate;
+      const fd = store.fromDate;
+      
       try {
-        return createNumericChartData(props.questionKey);
+        return createNumericChartData(props.questionKey, fd, ud);
       } catch (e) {
         console.error("Error preparing candlestick data:", e);
         return { datasets: [] };

--- a/src/components/surveys/ChartCard.vue
+++ b/src/components/surveys/ChartCard.vue
@@ -106,12 +106,8 @@ export default defineComponent({
     });
 
     const numericChartData = computed(() => {
-      const rangeEnd = store.responseRange[1];
-      const ud = rangeEnd !== undefined ? new Date(rangeEnd) : store.getMaxResponseDate;
-      const fd = store.fromDate;
-
       try {
-        return createNumericChartData(props.questionKey, fd, ud);
+        return createNumericChartData(props.questionKey);
       } catch (e) {
         console.error("Error preparing candlestick data:", e);
         return { datasets: [] };

--- a/src/components/surveys/ChartCard.vue
+++ b/src/components/surveys/ChartCard.vue
@@ -106,11 +106,10 @@ export default defineComponent({
     });
 
     const numericChartData = computed(() => {
-      const timestamp = new Date().toISOString();
       const rangeEnd = store.responseRange[1];
       const ud = rangeEnd !== undefined ? new Date(rangeEnd) : store.getMaxResponseDate;
       const fd = store.fromDate;
-      
+
       try {
         return createNumericChartData(props.questionKey, fd, ud);
       } catch (e) {

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -174,7 +174,7 @@ export function aggregateResponses(data: FilteredResponse[]): FilteredResponse[]
   return aggregatedData;
 }
 
-export function createNumericChartData(questionKey: string): ChartData<"candlestick"> {
+export function createNumericChartData(questionKey: string, fromDate: Date, untilDate: Date): ChartData<"candlestick"> {
   const store = useSurveyStore();
 
   if (store.selectedSurveyID === undefined) {
@@ -184,11 +184,11 @@ export function createNumericChartData(questionKey: string): ChartData<"candlest
 
   const question_type = store.getQuestionType(questionKey);
 
-  const filteredResponses = aggregateResponses(store.getFilteredResponses(questionKey));
+  const allResponses = aggregateResponses(store.getAllResponses(questionKey));
   store.updateTokenMap(store.selectedSurveyID);
 
   if (isNumericalQuestion(question_type)) {
-    return getOHLC(filteredResponses, questionKey);
+    return getOHLC(allResponses, questionKey, fromDate, untilDate);
   }
 
   console.debug("Not a numerical question, returning empty dataset");

--- a/src/helpers/chartFunctions.ts
+++ b/src/helpers/chartFunctions.ts
@@ -174,7 +174,7 @@ export function aggregateResponses(data: FilteredResponse[]): FilteredResponse[]
   return aggregatedData;
 }
 
-export function createNumericChartData(questionKey: string, fromDate: Date, untilDate: Date): ChartData<"candlestick"> {
+export function createNumericChartData(questionKey: string): ChartData<"candlestick"> {
   const store = useSurveyStore();
 
   if (store.selectedSurveyID === undefined) {
@@ -188,7 +188,7 @@ export function createNumericChartData(questionKey: string, fromDate: Date, unti
   store.updateTokenMap(store.selectedSurveyID);
 
   if (isNumericalQuestion(question_type)) {
-    return getOHLC(allResponses, questionKey, fromDate, untilDate);
+    return getOHLC(allResponses, questionKey);
   }
 
   console.debug("Not a numerical question, returning empty dataset");

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -128,7 +128,7 @@ function isResponseActive(response: FilteredResponse, targetDate: Date, expirati
   return response.time <= targetDate && expirationTime >= targetDate;
 }
 
-function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[] {
+function aggregateActiveResponses(data: FilteredResponse[], fromDate: Date, untilDate: Date): ExtendedHLResponse[] {
   const store = useSurveyStore();
   const expirationDays = store.settings.expirationTime;
   const expirationMs = expirationDays * DAY_IN_MS;
@@ -144,8 +144,8 @@ function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[
 
   if (numericResponses.length === 0) return [];
 
-  const rangeStart = alignToUnit(store.fromDate, timeUnit);
-  const rangeEndMs = store.untilDate.getTime();
+  const rangeStart = new Date(fromDate);
+  const rangeEndMs = untilDate.getTime();
 
   if (bucketDurationMs <= 0) {
     return [];
@@ -284,12 +284,11 @@ export function setMinMaxFromDataset(filteredResponses: FilteredResponse[], ques
   store.setMinMax(minMax, questionKey);
 }
 
-export function getOHLC(data: FilteredResponse[], questionKey: string): ChartData<"candlestick"> {
-  const hldata = aggregateActiveResponses(data);
+export function getOHLC(data: FilteredResponse[], questionKey: string, fromDate: Date, untilDate: Date): ChartData<"candlestick"> {
+  const hldata = aggregateActiveResponses(data, fromDate, untilDate);
   const datasets: ExtendedFinancialDataPoint[] = [];
 
   hldata.forEach((item) => {
-    console.debug(`Processing date: ${item.time.toISOString()}, values: ${item.values.length}`);
     const sortedValues = [...item.values].sort((a, b) => a - b);
     const mid = Math.floor(sortedValues.length / 2);
     let median = 0;

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -235,24 +235,6 @@ function getBucketDuration(unit: TimeUnit): number {
   }
 }
 
-function alignToUnit(date: Date, unit: TimeUnit): Date {
-  const aligned = new Date(date);
-
-  switch (unit) {
-    case "minute":
-      aligned.setSeconds(0, 0);
-      break;
-    case "hour":
-      aligned.setMinutes(0, 0, 0);
-      break;
-    default:
-      aligned.setHours(0, 0, 0, 0);
-      break;
-  }
-
-  return aligned;
-}
-
 export function setMinMaxFromDataset(filteredResponses: FilteredResponse[], questionKey: string) {
   // TODO: Remove seems to be obsolete
   const store = useSurveyStore();

--- a/src/helpers/numerical-charts.ts
+++ b/src/helpers/numerical-charts.ts
@@ -128,7 +128,7 @@ function isResponseActive(response: FilteredResponse, targetDate: Date, expirati
   return response.time <= targetDate && expirationTime >= targetDate;
 }
 
-function aggregateActiveResponses(data: FilteredResponse[], fromDate: Date, untilDate: Date): ExtendedHLResponse[] {
+function aggregateActiveResponses(data: FilteredResponse[]): ExtendedHLResponse[] {
   const store = useSurveyStore();
   const expirationDays = store.settings.expirationTime;
   const expirationMs = expirationDays * DAY_IN_MS;
@@ -144,8 +144,8 @@ function aggregateActiveResponses(data: FilteredResponse[], fromDate: Date, unti
 
   if (numericResponses.length === 0) return [];
 
-  const rangeStart = new Date(fromDate);
-  const rangeEndMs = untilDate.getTime();
+  const rangeStart = new Date(store.fromDate);
+  const rangeEndMs = store.untilDate.getTime();
 
   if (bucketDurationMs <= 0) {
     return [];
@@ -266,8 +266,8 @@ export function setMinMaxFromDataset(filteredResponses: FilteredResponse[], ques
   store.setMinMax(minMax, questionKey);
 }
 
-export function getOHLC(data: FilteredResponse[], questionKey: string, fromDate: Date, untilDate: Date): ChartData<"candlestick"> {
-  const hldata = aggregateActiveResponses(data, fromDate, untilDate);
+export function getOHLC(data: FilteredResponse[], questionKey: string): ChartData<"candlestick"> {
+  const hldata = aggregateActiveResponses(data);
   const datasets: ExtendedFinancialDataPoint[] = [];
 
   hldata.forEach((item) => {

--- a/src/store/surveyStore.ts
+++ b/src/store/surveyStore.ts
@@ -122,7 +122,8 @@ export const useSurveyStore = defineStore(
       if (typeof responses.value[selectedSurveyID.value] === "undefined") {
         return new Date();
       }
-      return maxResponseDate(responses.value[selectedSurveyID.value]);
+      const maxDate = maxResponseDate(responses.value[selectedSurveyID.value]);
+      return maxDate;
     });
 
     const fromDate = computed<Date>(() => {
@@ -133,10 +134,14 @@ export const useSurveyStore = defineStore(
     });
 
     const untilDate = computed<Date>(() => {
-      if (responseRange.value[1] === undefined) {
-        return getMaxResponseDate.value;
+      const rangeEnd = responseRange.value[1];
+      const timestamp = new Date().toISOString();
+      if (rangeEnd === undefined) {
+        const maxDate = getMaxResponseDate.value;
+        return maxDate;
       }
-      return new Date(responseRange.value[1]);
+      const result = new Date(rangeEnd);
+      return result;
     });
 
     const getExpireDate = computed<Date>(() => {
@@ -197,6 +202,18 @@ export const useSurveyStore = defineStore(
         .sort((a, b) => a.time.valueOf() - b.time.valueOf());
     }
 
+    function getAllResponses(qid: string): FilteredResponse[] {
+      return getResponses.value
+        .map((response) => {
+          if (isMultipleChoiceQuestion(getQuestionType(qid))) {
+            const { available_answers } = getQuestions.value[qid];
+            return multipleChoiceResponseMapper(available_answers || qid, response);
+          }
+          return responseMapper(qid, response);
+        })
+        .sort((a, b) => a.time.valueOf() - b.time.valueOf());
+    }
+
     function getQuestionType(qid: string): string {
       const question = getQuestions.value[qid];
       if (question === undefined || question.question_theme_name === undefined) {
@@ -212,9 +229,9 @@ export const useSurveyStore = defineStore(
           ...survey,
           ...(typeof surveys.value[survey.sid] !== "undefined"
             ? {
-                details: surveys.value[survey.sid].details,
-                questions: surveys.value[survey.sid].questions,
-              }
+              details: surveys.value[survey.sid].details,
+              questions: surveys.value[survey.sid].questions,
+            }
             : {}),
         };
       }
@@ -389,6 +406,7 @@ export const useSurveyStore = defineStore(
       setMinMax,
       getQuestionType,
       getFilteredResponses,
+      getAllResponses,
       updateSurveyList,
       refreshSurvey,
       refreshSurveys,

--- a/src/store/surveyStore.ts
+++ b/src/store/surveyStore.ts
@@ -135,7 +135,6 @@ export const useSurveyStore = defineStore(
 
     const untilDate = computed<Date>(() => {
       const rangeEnd = responseRange.value[1];
-      const timestamp = new Date().toISOString();
       if (rangeEnd === undefined) {
         const maxDate = getMaxResponseDate.value;
         return maxDate;
@@ -229,9 +228,9 @@ export const useSurveyStore = defineStore(
           ...survey,
           ...(typeof surveys.value[survey.sid] !== "undefined"
             ? {
-              details: surveys.value[survey.sid].details,
-              questions: surveys.value[survey.sid].questions,
-            }
+                details: surveys.value[survey.sid].details,
+                questions: surveys.value[survey.sid].questions,
+              }
             : {}),
         };
       }


### PR DESCRIPTION
When users moved the time slider to select a precise time range, the candlestick charts would incorrectly show data extended to midnight boundaries, not respecting the exact slider position.
Root cause was date rounding to midnight in TimeSlider, and Vue reactivity caching bug - store.untilDate returned stale cached values when accessed from computed properties.

Changes:
- Remove midnight boundary rounding in TimeSlider (getMidnight functions)
- Remove alignToUnit date rounding in aggregateActiveResponses
- Pass dates as parameters to createNumericChartData and aggregateActiveResponses
- Access responseRange directly in ChartCard for proper reactivity


<img width="560" height="181" alt="image" src="https://github.com/user-attachments/assets/cb5e81fe-9ebd-4449-907c-d4b385810bb6" />
<img width="954" height="227" alt="image" src="https://github.com/user-attachments/assets/37d425bc-d424-462a-9352-361c810ff261" />
